### PR TITLE
Added openssh 9.8p1 to the tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ This repository is for deploying general purpose system software that is used on
 
 * `gh` : [GitHub CLI](https://cli.github.com) is GitHub on the command line. It brings pull requests, issues, and other GitHub concepts to the terminal next to where you are already working with git and your code.
 
+* `openssh` : [OpenSSH](https://www.openssh.com/) is the premier connectivity tool for remote login with the SSH protocol. It encrypts all traffic to eliminate eavesdropping, connection hijacking, and other attacks. In addition, _OpenSSH_ provides a large suite of secure tunneling capabilities, several authentication methods, and sophisticated configuration options.
+The OpenSSH suite consists of the following tools:
+  - Remote operations are done using `ssh`, `scp`, and `sftp`.
+  - Key management with `ssh-add`, `ssh-keysign`, `ssh-keyscan`, and `ssh-keygen`.
+  - The service side consists of `sshd`, `sftp-server`, and `ssh-agent`.
+
 ## How to use
 
 **Requirements**: you must be a member of [`vk83`](https://my.nci.org.au/mancini/project/vk83).

--- a/openssh/spack.yaml
+++ b/openssh/spack.yaml
@@ -1,4 +1,4 @@
-# This is a Spack Environment file
+# This is a Spack Environment file.
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.

--- a/openssh/spack.yaml
+++ b/openssh/spack.yaml
@@ -1,0 +1,23 @@
+# This is a Spack Environment file
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+#
+# This manifest is for installing ncdu, a terminal user interface for du (disk usage)
+spack:
+  specs:
+    - openssh@9.8p1
+  packages:
+    openssh:
+      require:
+        - '%gcc@14.1.0'
+  view: true
+  concretizer:
+    unify: true
+  modules:
+    default:
+      tcl:
+        include:
+          - openssh
+        projections:
+          openssh: 'system-tools/{name}/{version}'

--- a/openssh/spack.yaml
+++ b/openssh/spack.yaml
@@ -3,7 +3,7 @@
 # It describes a set of packages to be installed, along with
 # configuration settings.
 #
-# This manifest is for installing ncdu, a terminal user interface for du (disk usage)
+# This manifest is for installing openssh, a suite of secure networking utilities based on the SSH protocol
 spack:
   specs:
     - openssh@9.8p1


### PR DESCRIPTION
Fixes #5
Added spack environment for `openssh`, installing version `9.8p1`.
This version of `openssh` is the same one found in the `payu` environment, and allows Git signing using SSH.

---
:rocket: The latest prerelease `openssh/pr6-3` at 00d16fb2be88d4536777b5e1b744975e29c93f3e is here: https://github.com/ACCESS-NRI/system-tools/pull/6#issuecomment-3067481998 :rocket:


