### PR TITLE
Fix ncdu version

### DIFF
--- a/ncdu/spack.yaml
+++ b/ncdu/spack.yaml
@@ -20,4 +20,4 @@ spack:
         include:
           - ncdu
         projections:
-          ncdu: 'system-tools/{name}/14.1.0'
+          ncdu: 'system-tools/{name}/{version}'


### PR DESCRIPTION
Switch to using `{version}` for `ncdu` projection. Closes #3 

---
:rocket: The latest prerelease `ncdu/pr7-1` at 5d1ab66715dca20c8b1a585533b7d53c6a8fb51c is here: https://github.com/ACCESS-NRI/system-tools/pull/7#issuecomment-3060941097 :rocket:
