### PR TITLE
Exploratory Infra Update `v6`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Tommy needs to review changes to infra
+/.github/ @CodeGat
+

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,10 +63,15 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-cd.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v5-model-tools
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v6
     with:
       model: ${{ matrix.manifest.name }}
       spack-manifest-path: ${{ matrix.manifest.path }}
+      # We have a custom schema for general software deployment manifests, so we specify it here
+      spack-manifest-schema-path: au.org.access-nri/tools/spack/environment/deployment
+      spack-manifest-schema-version: 1-0-0
+      config-versions-schema-version: 3-0-0
+      config-packages-schema-version: 1-0-0
       # This is a non-model deployment repository, so we do not want to tag the deployment or upload to the build database
       tag-deployment: false
       upload-to-build-db: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,11 +105,16 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v5-model-tools
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v6
     with:
       model: ${{ matrix.manifest.name }}
       pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
       spack-manifest-path: ${{ matrix.manifest.path }}
+      # We have a custom schema for general software deployment manifests, so we specify it here
+      spack-manifest-schema-path: au.org.access-nri/tools/spack/environment/deployment
+      spack-manifest-schema-version: 1-0-0
+      config-versions-schema-version: 3-0-0
+      config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
       contents: write
@@ -130,7 +135,7 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v5-model-tools
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v6
     with:
       root-sbd: ${{ matrix.manifest.name }}
     secrets: inherit

--- a/config/packages.json
+++ b/config/packages.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/packages/1-0-0.json",
+  "provenance": [],
+  "injection": []
+}


### PR DESCRIPTION
References ACCESS-NRI/build-cd#311 and https://github.com/ACCESS-NRI/build-cd/issues/276

## Background

Eventually we want to get software deployment repositories off the `v5-model-tools` branch of `build-cd`. We need to confirm that SDRs work with `v6` and if not, what changes need to be made. 

Use this PR to test Prereleases using the new infra.

> [!NOTE]
> Requires a new schema for spack manifests that deal with general software deployment

## The PR

- **Add empty packages.json as it is repo-scoped and we don't use the build database**
- **Add basic CODEOWNERS file**
- **Update to v6, add custom spack-manifest-schema-path**

## Testing

Add when done
