### PR TITLE
Added `pinentry` to system-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ The OpenSSH suite consists of the following tools:
 > OpenSSH system-tool was added primarily for [git signing on Gadi](https://github.com/ACCESS-NRI/dev-docs/wiki/Git-and-Github#sign-commits-on-gadi).
 > For all other use cases, we recommend using Gadi's system OpenSSH distribution, as ACCESS-NRI has not tested or validated this library configuration for security compliance.
 
+### pinentry
+[pinentry](https://www.gnupg.org/related_software/pinentry/index.html) is a small collection of dialog programs that allow GnuPG to read passphrases and PIN numbers in a secure manner. 
+
+> [!WARNING]
+> pinentry system-tool was added primarily for [mosrs-auth simple password input dialog](https://github.com/ACCESS-NRI/dev-docs/wiki/Git-and-Github#mosrs-auth-simple-password-input-dialog).
+> For all other use cases, we recommend using Gadi's system pinentry, as ACCESS-NRI has not tested or validated this library configuration for security compliance.
+
 ## How to use
 
 **Requirements**: you must be a member of [`vk83`](https://my.nci.org.au/mancini/project/vk83).

--- a/pinentry/spack.yaml
+++ b/pinentry/spack.yaml
@@ -1,0 +1,23 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+#
+# This manifest is for installing openssh, a suite of secure networking utilities based on the SSH protocol
+spack:
+  specs:
+    - pinentry@1.3.1 gui=tty
+  packages:
+    pinentry:
+      require:
+        - '%gcc@14.1.0'
+  view: true
+  concretizer:
+    unify: true
+  modules:
+    default:
+      tcl:
+        include:
+          - pinentry
+        projections:
+          openssh: 'system-tools/{name}/{version}'


### PR DESCRIPTION
Context can be found in #11
- [x] Added `pinentry` with `gui=tty` variant to system-tools