### PR TITLE
Add `yq` to `system-tools`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This repository is for deploying general purpose system software that is used on HPC targets, in this case gadi@NCI utilising the [build-cd](https://github.com/ACCESS-NRI/build-cd) infrastructure.
 
+## Versioning
+
+Versioning of tools in this repository consists of taking the official versions defined in the package, and appending a build number to the end of it (eg., for `yq 4.45.4`, the version would be `4.45.4-1`). This is so we are able to make changes unrelated to the package itself (eg. updating compilers and other lower-level dependenceis) without needing to wait and bundle changes until the next official release of a package we don't control. 
+
 ## Supported tools
 
 ### ncdu
@@ -29,6 +33,10 @@ The OpenSSH suite consists of the following tools:
 > [!WARNING]
 > pinentry system-tool was added primarily for [mosrs-auth simple password input dialog](https://github.com/ACCESS-NRI/dev-docs/wiki/MOSRS#mosrs-auth-with-a-simple-password-input-dialog).
 > For all other use cases, we recommend using Gadi's system pinentry, as ACCESS-NRI has not tested or validated this library configuration for security compliance.
+
+### yq
+
+[yq](https://mikefarah.gitbook.io/yq) is a lightweight YAML processor. 
 
 ## How to use
 

--- a/yq/spack.yaml
+++ b/yq/spack.yaml
@@ -8,7 +8,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [yq]
-  - _version: [4.45.4]
+  - _version: [4.45.4-1]
   specs:
   - yq@4.45.4
   packages:
@@ -32,7 +32,7 @@ spack:
     default:
       tcl:
         include:
-        - pinentry
+        - yq
         projections:
           # build-cd will inject the _version into this projection
-          pinentry: 'system-tools/{name}'
+          yq: 'system-tools/{name}'

--- a/yq/spack.yaml
+++ b/yq/spack.yaml
@@ -1,0 +1,38 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+#
+# This manifest is for installing yq, a command-line YAML processor.
+spack:
+  definitions:
+  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
+  - _name: [yq]
+  - _version: [4.45.4]
+  specs:
+  - yq@4.45.4
+  packages:
+    # Compilers
+    c:
+      require:
+      - 'gcc@15.1.0'
+    cxx:
+      require:
+      - 'gcc@15.1.0'
+    fortran:
+      require:
+      - 'gcc@15.1.0'
+    all:
+      prefer:
+      - 'target=x86_64_v3'
+  view: true
+  concretizer:
+    unify: true
+  modules:
+    default:
+      tcl:
+        include:
+        - pinentry
+        projections:
+          # build-cd will inject the _version into this projection
+          pinentry: 'system-tools/{name}'


### PR DESCRIPTION
Closes #10

## Background

`yq` is a useful YAML processor that is used across Gadi for interrogation and manipulation of YAML. 

This PR adds `yq/spack.yaml`, a manifest for the latest `yq` package using `gcc@15.1.0`. 

## Testing

Tested using the prerelease module, and it works fine!

---
:rocket: The latest prerelease `yq/pr24-2` at 803c73ba2df31f449dd0eca682648ee0359d66fd is here: https://github.com/ACCESS-NRI/system-tools/pull/24#issuecomment-3912385275 :rocket:



---
:rocket: The latest prerelease `yq/pr24-3` at 379bb256c57fb86ce05e869666e8b114a6136566 is here: https://github.com/ACCESS-NRI/system-tools/pull/24#issuecomment-3917846606 :rocket:
