### PR TITLE
Add git

### DIFF
--- a/git/spack.yaml
+++ b/git/spack.yaml
@@ -8,9 +8,9 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [git]
-  - _version: [2.53.0]
+  - _version: [2.53.0-0]
   specs:
-  - gh
+  - git@2.53.0
   packages:
     # Compilers
     c:

--- a/git/spack.yaml
+++ b/git/spack.yaml
@@ -35,4 +35,4 @@ spack:
         - git
         projections:
           # build-cd will inject the _version into this projection
-          git: 'system-tools/{name}'
+          git: 'system-tools/{name}/{version}'

--- a/git/spack.yaml
+++ b/git/spack.yaml
@@ -1,0 +1,38 @@
+# This is a Spack Environment file
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+#
+# This manifest is for installing gh, the GitHub command line interface
+spack:
+  definitions:
+  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
+  - _name: [git]
+  - _version: [2.53.0]
+  specs:
+  - gh
+  packages:
+    # Compilers
+    c:
+      require:
+      - 'gcc@15.1.0'
+    cxx:
+      require:
+      - 'gcc@15.1.0'
+    fortran:
+      require:
+      - 'gcc@15.1.0'
+    all:
+      prefer:
+      - 'target=x86_64_v3'
+  view: true
+  concretizer:
+    unify: true
+  modules:
+    default:
+      tcl:
+        include:
+        - git
+        projections:
+          # build-cd will inject the _version into this projection
+          git: 'system-tools/{name}'


### PR DESCRIPTION
Needed a newer version of git for testing. 

Require the `--empty=drop` option which is not available on any system `git` versions. 

Depending on outcome might want to merge this.

---
:rocket: The latest prerelease `git/pr25-3` at bdbcb9829abf5fb7ed50c52c943a7d10fb967e50 is here: https://github.com/ACCESS-NRI/system-tools/pull/25#issuecomment-4494789237 :rocket:


