### PR TITLE
Update all projections to include `{version}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ It also works without the `system-tools` namespace:
 module avail ncdu
 ```
 
+## Development
+
+How this repository is developed is essentially in line with `ACCESS-NRI/software-deployment-template`, but with the caveat that we use the `system-tools` prefix in the module projections, to note it is a system tool rather than a model itself.
+
 ## Support
 
 This repository and the software deployed from it are supported by ACCESS-NRI.

--- a/gh/spack.yaml
+++ b/gh/spack.yaml
@@ -35,4 +35,4 @@ spack:
         - gh
         projections:
           # build-cd will inject the _version into this projection
-          gh: 'system-tools/{name}'
+          gh: 'system-tools/{name}/{version}'

--- a/ncdu/spack.yaml
+++ b/ncdu/spack.yaml
@@ -35,4 +35,4 @@ spack:
         - ncdu
         projections:
           # build-cd will inject the _version into this projection
-          ncdu: 'system-tools/{name}'
+          ncdu: 'system-tools/{name}/{version}'

--- a/openssh/spack.yaml
+++ b/openssh/spack.yaml
@@ -35,4 +35,4 @@ spack:
         - openssh
         projections:
           # build-cd will inject the _version into this projection
-          openssh: 'system-tools/{name}'
+          openssh: 'system-tools/{name}/{version}'

--- a/pinentry/spack.yaml
+++ b/pinentry/spack.yaml
@@ -35,4 +35,4 @@ spack:
         - pinentry
         projections:
           # build-cd will inject the _version into this projection
-          pinentry: 'system-tools/{name}'
+          pinentry: 'system-tools/{name}/{version}'


### PR DESCRIPTION
## Background

Pre- https://github.com/ACCESS-NRI/build-cd/pull/382, the projection injection logic injected the reserved definition `_version` into the projection. This was a bit convoluted, and difficult to understand for users. In the linked PR, we have updated that logic to instead inject `{version}` with `_version` for things in the speclist. 

## The PR

* Update all `*/spack.yaml` to include `{version}` in the projection.
