### PR TITLE
Add cmake build environment

### DIFF
--- a/cmake/spack.yaml
+++ b/cmake/spack.yaml
@@ -1,0 +1,37 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+#
+# This manifest is for installing yq, a command-line YAML processor.
+spack:
+  definitions:
+  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
+  - _name: [cmake]
+  - _version: [4.2.3-1]
+  specs:
+  - cmake@4.2.3
+  packages:
+    # Compilers
+    c:
+      require:
+      - 'gcc@15.1.0'
+    cxx:
+      require:
+      - 'gcc@15.1.0'
+    fortran:
+      require:
+      - 'gcc@15.1.0'
+    all:
+      prefer:
+      - 'target=x86_64_v3'
+  view: true
+  concretizer:
+    unify: true
+  modules:
+    default:
+      tcl:
+        include:
+        - yq
+        projections:
+          yq: 'system-tools/{name}/{version}'


### PR DESCRIPTION
Add a `cmake` environment as a test for a stable pre-installed external cmake for spack builds.

---
:rocket: The latest prerelease `cmake/pr28-1` at 6f392e8c86f8e99b4f3a6477b6a0aeb34d85f915 is here: https://github.com/ACCESS-NRI/system-tools/pull/28#issuecomment-4538938082 :rocket:
